### PR TITLE
Show a basic Json example, add a new combinator for code

### DIFF
--- a/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -177,6 +177,13 @@ object Doc {
    */
   def group(doc: Doc): Doc = Union(flatten(doc), doc)
 
+  /**
+   * Either take the current Doc and remove all lines
+   * and prefix with a space, or prefix with a newline.
+   */
+  def spaceGroup(doc: Doc): Doc =
+    Union(Doc.space ++ flatten(doc), Doc.line ++ doc)
+
   def renderStream(d: Doc, width: Int): Stream[String] =
     Doc2.best(width, d).map(_.str)
 

--- a/src/test/scala/com/github/johnynek/paiges/JsonTest.scala
+++ b/src/test/scala/com/github/johnynek/paiges/JsonTest.scala
@@ -1,0 +1,87 @@
+package com.github.johnynek.paiges
+
+import org.scalatest.FunSuite
+
+/**
+ * A simple JSON ast
+ */
+sealed abstract class Json {
+  def toDoc: Doc
+}
+
+object Json {
+  def escape(str: String): String =
+    str.flatMap {
+      case '\\' => "\\\\"
+      case '\n' => "\\n"
+      case '"' => "\""
+      case other => other.toString
+    }
+
+  case class JString(str: String) extends Json {
+    def toDoc = Doc("\"%s\"".format(escape(str)))
+  }
+  case class JNumber(toDouble: Double) extends Json {
+    def toDoc = Doc(toDouble)
+  }
+  case class JBool(toBoolean: Boolean) extends Json {
+    def toDoc = Doc(toBoolean)
+  }
+  case object JNull extends Json {
+    def toDoc = Doc("null")
+  }
+  case class JArray(toVector: Vector[Json]) extends Json {
+    def toDoc = {
+      val parts = Doc.intercalate(Doc.comma, toVector.map { j => Doc.spaceGroup(j.toDoc) })
+      Doc("[") ++ ((parts ++ Doc(" ]")).nest(2))
+    }
+  }
+  case class JObject(toMap: Map[String, Json]) extends Json {
+    def toDoc = {
+      val kvs = toMap.map { case (s, j) =>
+        JString(s).toDoc ++ Doc(":") ++ ((Doc.spaceOrLine ++ j.toDoc).nest(2))
+      }
+      val parts = Doc.fill(Doc.comma, kvs)
+      parts.bracketBy("{", "}")
+    }
+  }
+}
+
+class JsonTest extends FunSuite {
+  import Json._
+
+  test("test nested array json example") {
+    val inner = JArray((1 to 20).map { i => JNumber(i.toDouble) }.toVector)
+    val outer = JArray(Vector(inner, inner, inner))
+
+    assert(outer.toDoc.render(20) ==
+"""[
+  [ 1.0, 2.0, 3.0,
+    4.0, 5.0, 6.0,
+    7.0, 8.0, 9.0,
+    10.0, 11.0,
+    12.0, 13.0,
+    14.0, 15.0,
+    16.0, 17.0,
+    18.0, 19.0,
+    20.0 ],
+  [ 1.0, 2.0, 3.0,
+    4.0, 5.0, 6.0,
+    7.0, 8.0, 9.0,
+    10.0, 11.0,
+    12.0, 13.0,
+    14.0, 15.0,
+    16.0, 17.0,
+    18.0, 19.0,
+    20.0 ],
+  [ 1.0, 2.0, 3.0,
+    4.0, 5.0, 6.0,
+    7.0, 8.0, 9.0,
+    10.0, 11.0,
+    12.0, 13.0,
+    14.0, 15.0,
+    16.0, 17.0,
+    18.0, 19.0,
+    20.0 ] ]""")
+  }
+}

--- a/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -140,7 +140,9 @@ object Generators {
     { (a: Doc, b: Doc) => a spaceOrLine b })
 
   val unary: Gen[Doc => Doc] =
-    Gen.oneOf( Gen.const({ d: Doc => d.group }),
+    Gen.oneOf(
+      Gen.const({ d: Doc => d.group }),
+      Gen.const({ d: Doc => Doc.spaceGroup(d) }),
       Gen.choose(0, 40).map { i => { d: Doc => d.nest(i) } })
 
   val folds: Gen[(List[Doc] => Doc)] =


### PR DESCRIPTION
Here I add a combinator (spaceGroup) which I *think* obeys the laws that it needs to in order to use with Union (namely that flatten of the union gives the same thing), but is useful for code situations where you want to continue on the line only if a whole block fits.

cc @non review?