### PR TITLE
Implement comparisons for Doc.

### DIFF
--- a/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -80,9 +80,64 @@ sealed abstract class Doc extends Serializable {
     Doc.write(this, maxLine, pw)
 
   override def toString: String = "Doc(...)"
+
+  /**
+   * Compare two Doc values; we expect that the comparison result
+   * should be valid across all possible rendering widths.
+   *
+   * This method *may* be overly conservative -- it assumes that
+   * documents need to have basically the same union structure when it
+   * comes to newlines on the "right-hand side". This may end up being
+   * a bit too cautious (i.e. some equal documents will be deemed
+   * unequal).
+   */
+  def compare(that: Doc): Int = {
+    import Doc.Tok
+
+    def extract(s: String, part: String): Option[Tok.Text] =
+      if (s.startsWith(part)) Some(Tok.Text(s.substring(part.length)))
+      else None
+
+    def loop(xs: Stream[Tok], ys: Stream[Tok]): Int =
+      (xs, ys) match {
+        case (Stream.Empty, Stream.Empty) => 0
+        case (Stream.Empty, _) => -1
+        case (_, Stream.Empty) => 1
+        case (Tok.Line(n1) #:: xs, Tok.Line(n2) #:: ys) =>
+          val c = n1 compare n2
+          if (c == 0) loop(xs, ys) else c
+        case (Tok.Line(_) #:: _, _) => -1
+        case (_, Tok.Line(_) #:: _) => 1
+        case (Tok.Text(s1) #:: xs, Tok.Text(s2) #:: ys) =>
+          lazy val c = s1 compare s2
+          if (s1.length == s2.length) {
+            if (c == 0) loop(xs, ys) else c
+          } else if (s1.length < s2.length) {
+            extract(s2, s1) match {
+              case Some(t) => loop(xs, t #:: ys)
+              case None => c
+            }
+          } else {
+            extract(s1, s2) match {
+              case Some(t) => loop(t #:: xs, ys)
+              case None => c
+            }
+          }
+      }
+
+    loop(Tok.fromDoc(this), Tok.fromDoc(that))
+  }
 }
 
 object Doc {
+
+  private case object Empty extends Doc
+  private case class Concat(a: Doc, b: Doc) extends Doc
+  private case class Nest(indent: Int, doc: Doc) extends Doc
+  private case class Text(str: String) extends Doc
+  private case object Line extends Doc
+  private case class Union(a: Doc, b: Doc) extends Doc
+
   private[this] val maxSpaceTable = 20
   private[this] val spaceArray: Array[Text] =
     (1 to maxSpaceTable).map { i => Text(" " * i) }.toArray
@@ -213,6 +268,7 @@ object Doc {
   sealed abstract class Doc2 {
     def str: String
   }
+
   private object Doc2 {
     @annotation.tailrec
     def fits(width: Int, d: Stream[Doc2]): Boolean =
@@ -268,10 +324,47 @@ object Doc {
     }
   }
 
-  private case object Empty extends Doc
-  private case class Concat(a: Doc, b: Doc) extends Doc
-  private case class Nest(indent: Int, doc: Doc) extends Doc
-  private case class Text(str: String) extends Doc
-  private case object Line extends Doc
-  private case class Union(a: Doc, b: Doc) extends Doc
+  /**
+   * Used internally by `Doc#compare`.
+   */
+  sealed abstract class Tok
+
+  object Tok {
+
+    /**
+     * Create a stream of Tok values from a Doc.
+     *
+     * Tok resembles Doc2, but with differences. It is designed to
+     * assist in comparisons and equality checks, not in rendering.
+     *
+     * We track how deeply nested unions are, and "save" that
+     * information in all the newlines that we find in those delimited
+     * regions.
+     */
+    def fromDoc(d: Doc): Stream[Tok] =
+      d match {
+        case Doc.Empty => Stream.empty
+        case Doc.Line => Line(0) #:: Stream.empty
+        case Doc.Text(s) => Tok.Text(s) #:: Stream.empty
+        case Doc.Concat(x, y) => fromDoc(x) #::: fromDoc(y)
+        case Doc.Nest(i, d) => fromDoc(d).flatMap {
+          case ln @ Tok.Line(_) => ln :: Tok.Text(" " * i) :: Nil
+          case x => x :: Nil
+        }
+        case Doc.Union(_, d) => fromDoc(d).map {
+          case Tok.Line(n) => Tok.Line(n + 1)
+          case x => x
+        }
+      }
+
+    /**
+     * Non-newline text, the normal case.
+     */
+    case class Text(s: String) extends Tok
+
+    /**
+     * Newline, together with how many levels of unions it contains.
+     */
+    case class Line(u: Int) extends Tok
+  }
 }

--- a/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -51,6 +51,19 @@ get rid of
 the spaces""")
   }
 
+  test("(x compare y) = (x.render(w) compare y.render(w))") {
+    forAll { (a: Doc, b: Doc, width: Int) =>
+      val sa = a.render(width)
+      val sb = b.render(width)
+
+      // we only care about three possible cases
+      def cmp(c: Int): Int =
+        if (c > 0) 1 else if (c < 0) -1 else 0
+
+      assert(cmp(a compare b) == cmp(sa compare sb))
+    }
+  }
+
   test("concat is associative") {
     forAll { (a: Doc, b: Doc, c: Doc, width: Int) =>
       assert(((a ++ b) ++ c).render(width) ==


### PR DESCRIPTION
This algorithm needs some thought put into it, but as a first-pass it
might possibly be correct.

The basic idea is this:

 1. Only the right-hand side of a union needs to be considered, since
    if those are equal we can be sure that they flatten to the same
    thing.

 2. Within the right-hand side of a union, only the presence (or
    absence) of newlines makes a difference -- all other text can be
    considered "the same" whether it is inside or outside a union.

 3. For a given newline, we need to track how many right-hand-side
    unions it is contained within, to determine the exact conditions
    when it may (or may not) be flattened. If two Docs have newlines
    at a given "position", they need to have the same "union
    structure" at that point to be equal.

Using these ideas, we generate a stream of `Tok` values (which are
similar, but not identical to, `Doc2` values). We then consume the
streams for two documents, looking for any possible discrepencies.

The comparison should be relatively efficient (O(n)), though in cases
where text concatenations differ there will be some number of extra
strings created via `substring`.