### PR TITLE
Remove spaceGroup. Sorry, it was late

### DIFF
--- a/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -177,13 +177,6 @@ object Doc {
    */
   def group(doc: Doc): Doc = Union(flatten(doc), doc)
 
-  /**
-   * Either take the current Doc and remove all lines
-   * and prefix with a space, or prefix with a newline.
-   */
-  def spaceGroup(doc: Doc): Doc =
-    Union(Doc.space ++ flatten(doc), Doc.line ++ doc)
-
   def renderStream(d: Doc, width: Int): Stream[String] =
     Doc2.best(width, d).map(_.str)
 
@@ -273,5 +266,11 @@ object Doc {
   private case class Nest(indent: Int, doc: Doc) extends Doc
   private case class Text(str: String) extends Doc
   private case object Line extends Doc
+  /**
+   * There is an additional invariant on Union that
+   * a == flatten(b). By construction all have this
+   * property, but this is why we don't expose Union
+   * but only .group
+   */
   private case class Union(a: Doc, b: Doc) extends Doc
 }

--- a/src/test/scala/com/github/johnynek/paiges/JsonTest.scala
+++ b/src/test/scala/com/github/johnynek/paiges/JsonTest.scala
@@ -32,7 +32,7 @@ object Json {
   }
   case class JArray(toVector: Vector[Json]) extends Json {
     def toDoc = {
-      val parts = Doc.intercalate(Doc.comma, toVector.map { j => Doc.spaceGroup(j.toDoc) })
+      val parts = Doc.intercalate(Doc.comma, toVector.map { j => (Doc.line ++ j.toDoc).group })
       Doc("[") ++ ((parts ++ Doc(" ]")).nest(2))
     }
   }

--- a/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -142,7 +142,6 @@ object Generators {
   val unary: Gen[Doc => Doc] =
     Gen.oneOf(
       Gen.const({ d: Doc => d.group }),
-      Gen.const({ d: Doc => Doc.spaceGroup(d) }),
       Gen.choose(0, 40).map { i => { d: Doc => d.nest(i) } })
 
   val folds: Gen[(List[Doc] => Doc)] =


### PR DESCRIPTION
.group really is all you have (or fancy ways to construct it) to keep the invariant that the algorithm leverages. In any case, I didn't need it since `spaceGroup(d) == group(Doc.line ++ d)` so why not use that directly.