### PR TITLE
Fix Doc.text() parsing errors.

### DIFF
--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -209,6 +209,12 @@ the spaces""")
     assert(ary.render(20) == expect)
   }
 
+  test("test Doc.text") {
+    forAll { (s: String) =>
+      assert(Doc.text(s).render(0) == s)
+    }
+  }
+
   test("test json map example") {
     val kvs = (0 to 20).map { i => text("\"%s\": %s".format(s"key$i", i)) }
     val parts = Doc.fill(Doc.comma, kvs)


### PR DESCRIPTION
Previously Doc.text did not handle newlines correctly in some
cases. For example, multiple newlines would be collapsed into one
newline. Similarly, I think trailing newlines were also discarded.

This code is slightly more imperative, but should do the right thing
in all cases, and also be relatively efficient.

I added a law to ensure that:

    Doc.text(s).render(0) = s