### PR TITLE
Make maxWidth stack safe and add renderTall and renderWide

### DIFF
--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -353,4 +353,8 @@ the spaces""")
       assert((Doc.text(s) * n).render(0) == (s * n))
     }
   }
+
+  test("maxWidth is stack safe") {
+    assert(Doc.intercalate(Doc.spaceOrLine, (1 to 100000).map(Doc.str)).maxWidth >= 0)
+  }
 }

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -357,4 +357,21 @@ the spaces""")
   test("maxWidth is stack safe") {
     assert(Doc.intercalate(Doc.spaceOrLine, (1 to 100000).map(Doc.str)).maxWidth >= 0)
   }
+
+  test("renderWide is stack safe") {
+    val nums = (1 to 100000)
+    assert(Doc.intercalate(Doc.spaceOrLine, nums.map(Doc.str)).renderWideStream.mkString == nums.mkString(" "))
+  }
+
+  test("renderTall == render(0)") {
+    forAll { (d: Doc) =>
+      assert(d.renderTallStream.mkString == d.render(0))
+    }
+  }
+  test("renderWide == render(maxWidth)") {
+    forAll { (d: Doc) =>
+      val max = d.maxWidth
+      assert(d.renderWideStream.mkString == d.render(max))
+    }
+  }
 }


### PR DESCRIPTION
This give you the ability to avoid the branching code, which can blow up for very (10k) wide widths due to stack overflows.

Since very wide widths are not the use case of this code, I think we are mostly okay with not solving the stack overflow for such unrealistic widths.

Another solution would be to check if the width is say bigger than 1000, then check if it is bigger than the max, which is safe, and if it is bigger than the max, we can use the stack safe `renderWide` method and get the same result. This will often in practice solve the problem but we should probably punt for now since I think all the main usability SOEs are handled.