### PR TITLE
Remove right-association in concat

### DIFF
--- a/benchmark/src/main/scala/Benchmark.scala
+++ b/benchmark/src/main/scala/Benchmark.scala
@@ -27,6 +27,9 @@ class PaigesBenchmark {
   // @Benchmark
   // def concat(): String =
   //   strs.reduceLeft(_ + ", " + _)
+  @Benchmark
+  def docConcat(): String =
+    strs.foldLeft(Doc.empty) { (d1, s) => d1 :+ s }.render(0)
 
   @Benchmark
   def intercalate(): String =
@@ -43,4 +46,5 @@ class PaigesBenchmark {
   @Benchmark
   def fill100(): String =
     Doc.fill(Doc.text(","), strs.map(Doc.text)).render(100)
+
 }

--- a/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
@@ -93,6 +93,12 @@ private object Chunk {
          * If we can fit the next line from x, we take it.
          */
         val first = cheat(pos, (i, x) :: z)
+        /**
+         * Note that in Union the left side is always right associated.
+         * This means the "fits" branch in rendering
+         * always has a right associated Doc which means it is O(w)
+         * to find if you can fit in width w.
+         */
         if (fits(pos, first)) first
         else loop(pos, (i, u.bDoc) :: z)
     }


### PR DESCRIPTION
It occurred to me: we already right-associate as part of the stack safety in flatten and flattenOption. As a result, the left side of a Union is already right associated no matter what we do. This property (and the fact that we unwind in the rendering loops already) breaks any O(N^2) performance.

I verified that with some benchmarks:
```
before:

[info] Benchmark                    (size)   Mode  Cnt      Score       Error   Units
[info] PaigesBenchmark.docConcat         1  thrpt    3   7271.123 ±  3786.344  ops/ms
[info] PaigesBenchmark.docConcat        10  thrpt    3   1127.478 ±   566.950  ops/ms
[info] PaigesBenchmark.docConcat       100  thrpt    3     27.731 ±    12.220  ops/ms
[info] PaigesBenchmark.docConcat      1000  thrpt    3      0.196 ±     0.012  ops/ms
[info] PaigesBenchmark.docConcat     10000  thrpt    3      0.002 ±     0.001  ops/ms
[info] PaigesBenchmark.fill              1  thrpt    3   6758.951 ±  1874.077  ops/ms
[info] PaigesBenchmark.fill             10  thrpt    3    992.742 ±    67.802  ops/ms
[info] PaigesBenchmark.fill            100  thrpt    3    105.708 ±    23.570  ops/ms
[info] PaigesBenchmark.fill           1000  thrpt    3     10.077 ±     0.527  ops/ms
[info] PaigesBenchmark.fill          10000  thrpt    3      0.954 ±     0.772  ops/ms
[info] PaigesBenchmark.fill0             1  thrpt    3   4284.970 ±   875.741  ops/ms
[info] PaigesBenchmark.fill0            10  thrpt    3    405.274 ±   135.203  ops/ms
[info] PaigesBenchmark.fill0           100  thrpt    3     40.118 ±    17.804  ops/ms
[info] PaigesBenchmark.fill0          1000  thrpt    3      4.055 ±     0.555  ops/ms
[info] PaigesBenchmark.fill0         10000  thrpt    3      0.383 ±     0.600  ops/ms
[info] PaigesBenchmark.fill100           1  thrpt    3   4133.444 ±  5187.297  ops/ms
[info] PaigesBenchmark.fill100          10  thrpt    3    366.609 ±   396.782  ops/ms
[info] PaigesBenchmark.fill100         100  thrpt    3     28.006 ±     3.910  ops/ms
[info] PaigesBenchmark.fill100        1000  thrpt    3      2.631 ±     0.677  ops/ms
[info] PaigesBenchmark.fill100       10000  thrpt    3      0.313 ±     0.112  ops/ms
[info] PaigesBenchmark.intercalate       1  thrpt    3   5124.273 ±  1666.794  ops/ms
[info] PaigesBenchmark.intercalate      10  thrpt    3    885.737 ±   156.115  ops/ms
[info] PaigesBenchmark.intercalate     100  thrpt    3    100.038 ±     8.381  ops/ms
[info] PaigesBenchmark.intercalate    1000  thrpt    3      9.171 ±     4.922  ops/ms
[info] PaigesBenchmark.intercalate   10000  thrpt    3      0.937 ±     0.804  ops/ms
[info] PaigesBenchmark.mkstring          1  thrpt    3  16543.735 ± 22436.725  ops/ms
[info] PaigesBenchmark.mkstring         10  thrpt    3   3792.448 ±   812.854  ops/ms
[info] PaigesBenchmark.mkstring        100  thrpt    3    421.648 ±   130.509  ops/ms
[info] PaigesBenchmark.mkstring       1000  thrpt    3     42.594 ±    25.004  ops/ms
[info] PaigesBenchmark.mkstring      10000  thrpt    3      4.629 ±     0.564  ops/ms

after
[info] Benchmark                    (size)   Mode  Cnt      Score      Error   Units
[info] PaigesBenchmark.docConcat         1  thrpt    3   7276.434 ± 3751.882  ops/ms
[info] PaigesBenchmark.docConcat        10  thrpt    3   1694.660 ±  287.643  ops/ms
[info] PaigesBenchmark.docConcat       100  thrpt    3    185.314 ±   33.240  ops/ms
[info] PaigesBenchmark.docConcat      1000  thrpt    3     17.140 ±    2.967  ops/ms
[info] PaigesBenchmark.docConcat     10000  thrpt    3      1.727 ±    0.246  ops/ms
[info] PaigesBenchmark.fill              1  thrpt    3   6918.803 ± 2140.622  ops/ms
[info] PaigesBenchmark.fill             10  thrpt    3   1043.449 ±  436.240  ops/ms
[info] PaigesBenchmark.fill            100  thrpt    3    111.763 ±   19.795  ops/ms
[info] PaigesBenchmark.fill           1000  thrpt    3     11.003 ±    6.272  ops/ms
[info] PaigesBenchmark.fill          10000  thrpt    3      0.997 ±    0.394  ops/ms
[info] PaigesBenchmark.fill0             1  thrpt    3   4394.953 ± 1730.850  ops/ms
[info] PaigesBenchmark.fill0            10  thrpt    3    402.138 ±  383.729  ops/ms
[info] PaigesBenchmark.fill0           100  thrpt    3     40.492 ±    3.267  ops/ms
[info] PaigesBenchmark.fill0          1000  thrpt    3      4.114 ±    0.454  ops/ms
[info] PaigesBenchmark.fill0         10000  thrpt    3      0.395 ±    0.097  ops/ms
[info] PaigesBenchmark.fill100           1  thrpt    3   4353.119 ±  557.545  ops/ms
[info] PaigesBenchmark.fill100          10  thrpt    3    406.700 ±   90.665  ops/ms
[info] PaigesBenchmark.fill100         100  thrpt    3     30.169 ±    6.833  ops/ms
[info] PaigesBenchmark.fill100        1000  thrpt    3      2.807 ±    0.923  ops/ms
[info] PaigesBenchmark.fill100       10000  thrpt    3      0.313 ±    0.178  ops/ms
[info] PaigesBenchmark.intercalate       1  thrpt    3   5340.003 ± 2000.812  ops/ms
[info] PaigesBenchmark.intercalate      10  thrpt    3    897.176 ±  269.250  ops/ms
[info] PaigesBenchmark.intercalate     100  thrpt    3    103.967 ±   14.309  ops/ms
[info] PaigesBenchmark.intercalate    1000  thrpt    3      9.767 ±    1.206  ops/ms
[info] PaigesBenchmark.intercalate   10000  thrpt    3      1.013 ±    0.173  ops/ms
[info] PaigesBenchmark.mkstring          1  thrpt    3  17555.149 ± 5272.955  ops/ms
[info] PaigesBenchmark.mkstring         10  thrpt    3   4455.296 ± 1117.310  ops/ms
[info] PaigesBenchmark.mkstring        100  thrpt    3    444.815 ±   64.634  ops/ms
[info] PaigesBenchmark.mkstring       1000  thrpt    3     43.614 ±    4.103  ops/ms
[info] PaigesBenchmark.mkstring      10000  thrpt    3      4.604 ±    2.041  ops/ms
```

Note that after this change everything is as fast or faster, and naive `a + b` loops are MUCH faster (avoiding an N^2 perf bottleneck there).

I think all that is required to keep this is to add an invariant to `Union` that the left side is right-associated, which I made a comment for. And again, we actually already had this property after #20 .