### PR TITLE
Add lineBreak and align

### DIFF
--- a/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
@@ -33,6 +33,9 @@ private object Chunk {
    * of Chunks.
    */
   def best(w: Int, d: Doc): Iterator[String] = {
+
+    val nonNegW = w max 0
+
     sealed abstract class ChunkStream
     object ChunkStream {
       case object Empty extends ChunkStream
@@ -54,6 +57,7 @@ private object Chunk {
         }
       }
     }
+
     class ChunkIterator(var current: ChunkStream) extends Iterator[String] {
       def hasNext: Boolean = (current != ChunkStream.Empty)
       def next: String = {
@@ -63,13 +67,12 @@ private object Chunk {
         res
       }
     }
-
     /**
      * Return the length of this line if it fits
      */
     @tailrec
     def fits(pos: Int, d: ChunkStream): Boolean =
-      (w >= pos) && {
+      (nonNegW >= pos) && {
         d match {
           case ChunkStream.Empty => true
           case item: ChunkStream.Item =>
@@ -86,6 +89,7 @@ private object Chunk {
       case (i, Doc.Empty) :: z => loop(pos, z)
       case (i, Doc.Concat(a, b)) :: z => loop(pos, (i, a) :: (i, b) :: z)
       case (i, Doc.Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z)
+      case (_, Doc.Align(d)) :: z => loop(pos, (pos, d) :: z)
       case (i, Doc.Text(s)) :: z => ChunkStream.Item(s, pos + s.length, z, false)
       case (i, Doc.Line(_)) :: z => ChunkStream.Item(null, i, z, true)
       case (i, u@Doc.Union(x, _)) :: z =>

--- a/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
@@ -87,7 +87,7 @@ private object Chunk {
       case (i, Doc.Concat(a, b)) :: z => loop(pos, (i, a) :: (i, b) :: z)
       case (i, Doc.Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z)
       case (i, Doc.Text(s)) :: z => ChunkStream.Item(s, pos + s.length, z, false)
-      case (i, Doc.Line) :: z => ChunkStream.Item(null, i, z, true)
+      case (i, Doc.Line(_)) :: z => ChunkStream.Item(null, i, z, true)
       case (i, u@Doc.Union(x, _)) :: z =>
         /**
          * If we can fit the next line from x, we take it.

--- a/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Doc.scala
@@ -13,7 +13,7 @@ import scala.util.matching.Regex
  */
 sealed abstract class Doc extends Product with Serializable {
 
-  import Doc.{ Empty, Text, Line, Nest, Concat, Union }
+  import Doc.{ Align, Empty, Text, Line, Nest, Concat, Union }
 
   /**
    * Append the given Doc to this one.
@@ -129,8 +129,7 @@ sealed abstract class Doc extends Product with Serializable {
     }
 
   /**
-   * Returns true if every call to .render will return the empty
-   * string (no matter what width is used); otherwise, returns false.
+   * Returns true if all renders return the empty string
    */
   def isEmpty: Boolean = {
     @tailrec def loop(doc: Doc, stack: List[Doc]): Boolean =
@@ -146,6 +145,7 @@ sealed abstract class Doc extends Product with Serializable {
           s.isEmpty && loop(a, stack)
         case Concat(a, b) => loop(a, b :: stack)
         case Nest(i, d) => loop(d, stack)
+        case Align(d) => loop(d, stack)
         case Text(s) =>
           // shouldn't be empty by construction, but defensive
           s.isEmpty && loop(Empty, stack)
@@ -156,6 +156,11 @@ sealed abstract class Doc extends Product with Serializable {
       }
     loop(this, Nil)
   }
+
+  /**
+   * d.nonEmpty == !d.isEmpty
+   */
+  def nonEmpty: Boolean = !isEmpty
 
   /**
    * Returns true if there is a width where these Docs render the same
@@ -189,37 +194,28 @@ sealed abstract class Doc extends Product with Serializable {
    * `d.render(w)`.
    */
   def renderStream(width: Int): Stream[String] =
-    if (width <= 0) renderTallStream
-    else Chunk.best(width, this).toStream
-
-  /**
-   * Render this Doc as a stream of strings, using
-   * the tallest possible variant. This is the same
-   * as render(0) except it is more efficient.
-   */
-  def renderTallStream: Stream[String] =
-    renderFixedDirection(tall = true)
+    Chunk.best(width, this).toStream
 
   /**
    * Render this Doc as a stream of strings, using
    * the widest possible variant. This is the same
    * as render(Int.MaxValue) except it is more efficient.
    */
-  def renderWideStream: Stream[String] =
-    renderFixedDirection(tall = false)
-
-  private def renderFixedDirection(tall: Boolean): Stream[String] = {
+  def renderWideStream: Stream[String] = {
     @tailrec
     def loop(pos: Int, lst: List[(Int, Doc)]): Stream[String] = lst match {
       case Nil => Stream.empty
       case (i, Empty) :: z => loop(pos, z)
       case (i, Concat(a, b)) :: z => loop(pos, (i, a) :: (i, b) :: z)
       case (i, Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z)
+      case (i, Align(d)) :: z => loop(pos, (pos, d) :: z)
       case (i, Text(s)) :: z => s #:: cheat(pos + s.length, z)
       case (i, Line(_)) :: z => Chunk.lineToStr(i) #:: cheat(i, z)
-      case (i, u@Union(a, _)) :: z =>
-        val next = if (tall) u.bDoc else a
-        loop(pos, (i, next) :: z)
+      case (i, Union(a, _)) :: z =>
+        /**
+         * if we are infinitely wide, a always fits
+         */
+        loop(pos, (i, a) :: z)
     }
     def cheat(pos: Int, lst: List[(Int, Doc)]) =
       loop(pos, lst)
@@ -263,6 +259,19 @@ sealed abstract class Doc extends Product with Serializable {
       case Nest(i, d) => Nest(i + amount, d)
       case _ => Nest(amount, this)
     }
+
+  /**
+   * aligned sets the nesting to the column position before we
+   * render the current doc. This is useful if you have:
+   *
+   * Doc.text("foo") + (Doc.text("bar").line(Doc.text("baz"))).align
+   *
+   * which will render as:
+   *
+   * foobar
+   *    baz
+   */
+  def aligned: Doc = Align(this)
 
   /**
    * Render this Doc at the given `width`, and write it to the given
@@ -336,6 +345,8 @@ sealed abstract class Doc extends Product with Serializable {
                   loop(tail, "Text(" +: s +: ")" +: suffix)
                 case Nest(i, d) =>
                   loop(Left(d) :: Right(", ") :: Right(i.toString) :: Right("Nest(") :: tail, ")" +: suffix)
+                case Align(d) =>
+                  loop(Left(d) :: Right("Align(") :: tail, ")" +: suffix)
                 case Concat(x, y) =>
                   loop(Left(y) :: Right(", ") :: Left(x) :: Right("Concat(") :: tail, ")" +: suffix)
                 case Union(x, y) =>
@@ -397,6 +408,7 @@ sealed abstract class Doc extends Product with Serializable {
           }
         case Line(flattenTo) => loop(flattenTo, stack, front)
         case Nest(i, d) => loop(d, stack, front) // no Line, so Nest is irrelevant
+        case Align(d) => loop(d, stack, front) // no Line, so Align is irrelevant
         case Union(a, _) => loop(a, stack, front) // invariant: flatten(union(a, b)) == flatten(a)
         case Concat(a, b) => loop(a, b :: stack, front)
       }
@@ -444,6 +456,13 @@ sealed abstract class Doc extends Product with Serializable {
            * no embedded Line inside
            */
           loop((d, h._2), stack, front) // no Line, so Nest is irrelevant
+        case Align(d) =>
+          /*
+           * This is different from flatten which always strips
+           * the Align node. This will return None if there is
+           * no embedded Line inside
+           */
+          loop((d, h._2), stack, front) // no Line, so Align is irrelevant
         case Union(a, _) => loop((a, true), stack, front) // invariant: flatten(union(a, b)) == flatten(a)
         case Concat(a, b) => loop((a, h._2), (b, h._2) :: stack, front)
       }
@@ -467,6 +486,7 @@ sealed abstract class Doc extends Product with Serializable {
       case (i, Empty) :: z => loop(pos, z, max)
       case (i, Concat(a, b)) :: z => loop(pos, (i, a) :: (i, b) :: z, max)
       case (i, Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z, max)
+      case (i, Align(d)) :: z => loop(pos, (pos, d) :: z, max)
       case (i, Text(s)) :: z => loop(pos + s.length, z, max)
       case (i, Line(_)) :: z => loop(i, z, math.max(max, pos))
       case (i, Union(a, _)) :: z =>
@@ -519,11 +539,16 @@ object Doc {
   private[paiges] case class Nest(indent: Int, doc: Doc) extends Doc
 
   /**
+   * Align sets the nesting at the current position
+   */
+  private[paiges] case class Align(doc: Doc) extends Doc
+
+  /**
    * Represents an optimistic rendering (on the left) as well as a
    * fallback rendering (on the right) if the first line of the left
    * is too long.
    *
-   * There is an additional invariant on Union: `a == flatten(b)`.
+   * There is an additional invariant on Union: `flatten(a) == flatten(b)`.
    *
    * By construction all `Union` nodes have this property; to preserve
    * this we don't expose the `Union` constructor directly, but only
@@ -535,7 +560,6 @@ object Doc {
    */
   private[paiges] case class Union(a: Doc, b: () => Doc) extends Doc {
     lazy val bDoc: Doc = b()
-    override def toString: String = s"Union($a, $bDoc)"
   }
 
   private[this] val maxSpaceTable = 20
@@ -564,7 +588,9 @@ object Doc {
   val line: Doc = Line(space)
   /**
    * A lineBreak is a line that is flattened into
-   * an empty Doc.
+   * an empty Doc. This is generally useful in code
+   * following tokens that parse without the need for
+   * whitespace termination (consider ";" "," "=>" etc..)
    */
   val lineBreak: Doc = Line(empty)
   val spaceOrLine: Doc = Union(space, () => line)
@@ -633,23 +659,23 @@ object Doc {
 
   /**
    * Collapse a collection of documents into one document, delimited
-   * by a separator and whitespace.
-   *
-   * The whitespace used (in addition to the separator) will be a
-   * space (if there is room) or a newline otherwise.
+   * by a separator.
    *
    * For example:
    *
-   *     import Doc.{ text, fill }
-   *     val comma = Doc.text(",")
+   *     import Doc.{ comma, line, text, fill }
    *     val ds = text("1") :: text("2") :: text("3") :: Nil
-   *     val doc = fill(comma, ds)
+   *     val doc = fill(comma + line, ds)
    *
    *     doc.render(0)  // produces "1,\n2,\n3"
    *     doc.render(6)  // produces "1, 2,\n3"
    *     doc.render(10) // produces "1, 2, 3"
    */
   def fill(sep: Doc, ds: Iterable[Doc]): Doc = {
+
+    val flatSep = sep.flatten
+    val sepGroup = sep.grouped
+
     @tailrec
     def fillRec(x: Doc, lst: List[Doc], stack: List[Doc => Doc]): Doc = lst match {
       case Nil => call(x, stack)
@@ -665,45 +691,37 @@ object Doc {
          *
          * which is exponential in n (O(2^n))
          *
-         * making the second parameter in the union lazy would fix this.
-         * that seems an expensive fix for a single combinator. Maybe
-         * there is an alternative way to express this that is not
-         * exponential.
-         *
-         * On top of this difficulty, this formulation creates
-         * Union nodes that violate the invariant that Union(a, b)
-         * means a == flatten(b). It still has flatten(a) == flatten(b),
-         * however. This fact seems to complicate comparison of Doc
-         * which is valuable.
+         * Making the second parameter in the union lazy fixes this.
+         * This is exactly the motivation for keeping the second
+         * parameter of Union lazy.
          */
-        val xsep = x + sep
-        (xsep.flattenOption, y.flattenOption) match {
+        (x.flattenOption, y.flattenOption) match {
           case (Some(flatx), Some(flaty)) =>
             def cont(resty: Doc) = {
-              val first = flatx.space(resty)
-              def second = xsep / cheatRec(y, tail)
+              val first = Concat(flatx, Concat(flatSep, resty))
+              def second = Concat(x, Concat(sep, cheatRec(y, tail)))
               // note that first != second
               Union(first, () => second)
             }
             fillRec(flaty, tail, (cont _) :: stack)
           case (Some(flatx), None) =>
             def cont(resty: Doc) = {
-              val first = flatx.space(resty)
-              def second = xsep / resty
+              val first = Concat(flatx, Concat(flatSep, resty))
+              val second = Concat(x, Concat(sep, resty))
               // note that first != second
               Union(first, () => second)
             }
             fillRec(y, tail, (cont _) :: stack)
           case (None, Some(flaty)) =>
             def cont(resty: Doc) = {
-              val first = xsep.space(resty)
-              def second = xsep / cheatRec(y, tail)
+              val first = Concat(x, Concat(flatSep, resty))
+              def second = Concat(x, Concat(sep, cheatRec(y, tail)))
               // note that first != second
               Union(first, () => second)
             }
             fillRec(flaty, tail, (cont _) :: stack)
           case (None, None) =>
-            fillRec(y, tail, (xsep.spaceOrLine(_: Doc)) :: stack)
+            fillRec(y, tail, { d: Doc => Concat(x, Concat(sepGroup, d)) } :: stack)
         }
     }
 

--- a/core/src/main/scala/com/github/johnynek/paiges/DocTree.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/DocTree.scala
@@ -51,10 +51,11 @@ object DocTree {
     @tailrec
     def loop(pos: Int, lst: List[(Int, Doc)], bounds: Bounds): DocTree = lst match {
       case Nil => docTree(Stream.empty)
-      case (i, Empty) :: z => loop(pos, z, bounds)
+      case (_, Empty) :: z => loop(pos, z, bounds)
       case (i, Concat(a, b)) :: z => loop(pos, (i, a) :: (i, b) :: z, bounds)
       case (i, Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z, bounds)
-      case (i, Text(s)) :: z => docTree(Emit(Str(s)) #:: cheat(pos + s.length, z, bounds).unfix)
+      case (_, Align(d)) :: z => loop(pos, (pos, d) :: z, bounds)
+      case (_, Text(s)) :: z => docTree(Emit(Str(s)) #:: cheat(pos + s.length, z, bounds).unfix)
       case (i, Line(_)) :: z => docTree(Emit(Break(i)) #:: cheat(i, z, bounds).unfix)
       case (i, u@Union(a, _)) :: z =>
         /**
@@ -64,7 +65,7 @@ object DocTree {
          * else go left
          */
         val as = cheat(pos, (i, a) :: z, bounds)
-        val minLeftWidth = fits(pos, as, Int.MaxValue)
+        val minLeftWidth = fits(pos, as, bounds.max)
         bounds.split(minLeftWidth) match {
           case None =>
             // cannot go left

--- a/core/src/main/scala/com/github/johnynek/paiges/DocTree.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/DocTree.scala
@@ -55,7 +55,7 @@ object DocTree {
       case (i, Concat(a, b)) :: z => loop(pos, (i, a) :: (i, b) :: z, bounds)
       case (i, Nest(j, d)) :: z => loop(pos, ((i + j), d) :: z, bounds)
       case (i, Text(s)) :: z => docTree(Emit(Str(s)) #:: cheat(pos + s.length, z, bounds).unfix)
-      case (i, Line) :: z => docTree(Emit(Break(i)) #:: cheat(i, z, bounds).unfix)
+      case (i, Line(_)) :: z => docTree(Emit(Break(i)) #:: cheat(i, z, bounds).unfix)
       case (i, u@Union(a, _)) :: z =>
         /**
          * if we can go left, we do, otherwise we go right. So, in the current
@@ -103,7 +103,7 @@ object DocTree {
         case (Emit(Str(t)) #:: tail) =>
           loop(docTree(tail), cat(prefix, Text(t)))
         case (Emit(Break(n)) #:: tail) =>
-          loop(docTree(tail), cat(prefix, cat(Line, spaces(n))))
+          loop(docTree(tail), cat(prefix, cat(line, spaces(n))))
         case (Split(a, b) #:: _) =>
           cheat(a, prefix) #::: cheat(b(), prefix)
       }

--- a/core/src/test/scala/com/github/johnynek/paiges/Generators.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/Generators.scala
@@ -18,6 +18,7 @@ object Generators {
     (1, Doc.empty),
     (1, Doc.space),
     (1, Doc.line),
+    (1, Doc.lineBreak),
     (1, Doc.spaceOrLine),
     (10, asciiString.map(text(_))),
     (10, generalString.map(text(_))),
@@ -36,14 +37,16 @@ object Generators {
   val unary: Gen[Doc => Doc] =
     Gen.oneOf(
       Gen.const({ d: Doc => d.grouped }),
+      Gen.const({ d: Doc => d.aligned }),
       Gen.choose(0, 40).map { i => { d: Doc => d.nest(i) } })
 
   val folds: Gen[(List[Doc] => Doc)] =
     Gen.oneOf(
-    // fill is exponentially expensive currently
-    { ds: List[Doc] => Doc.fill(Doc.empty, ds.take(6)) },
-    { ds: List[Doc] => Doc.spread(ds) },
-    { ds: List[Doc] => Doc.stack(ds) })
+    doc0Gen.map { sep =>
+      { ds: List[Doc] => Doc.fill(sep, ds.take(8)) }
+    },
+    Gen.const({ ds: List[Doc] => Doc.spread(ds) }),
+    Gen.const({ ds: List[Doc] => Doc.stack(ds) }))
 
   val maxDepth = 7
 

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -101,23 +101,17 @@ the spaces""")
     }
   }
 
-  test("isEmpty == true means render is empty String") {
-    forAll { (d: Doc, w0: Int, ws: List[Int]) =>
-      if (d.isEmpty) (w0 :: ws).foreach { w =>
-        val str = d.render(w)
-        assert(str.isEmpty, s"width: $w gave str: $str, should be empty")
+  test("isEmpty == render(w).isEmpty for all w") {
+    forAll { (d: Doc) =>
+      if (d.isEmpty) {
+        assert((0 to d.maxWidth).forall(d.render(_).isEmpty), s"${d.representation(true).render(50)} has nonEmpty renderings")
       }
       else succeed
     }
   }
-  test("renders to empty implies isEmpty == true") {
-    forAll { (d: Doc, w0: Int, ws: List[Int]) =>
-      val emptyWidth = (w0 :: ws).find { w =>
-        d.render(w).isEmpty
-      }
-      emptyWidth.foreach { w =>
-        assert(d.isEmpty, s"width $w renders empty, but !d.isEmpty")
-      }
+  test("nonEmpty == !isEmpty") {
+    forAll { (d: Doc) =>
+      assert(d.nonEmpty == !d.isEmpty)
     }
   }
   test("isEmpty compare empty == 0") {
@@ -145,6 +139,12 @@ the spaces""")
       else succeed
     }
   }
+  test("render(w) == render(0) for w <= 0") {
+    forAll { (a: Doc, w: Int) =>
+      val wNeg = if (w > 0) -w else w
+      assert(a.render(wNeg) == a.render(0), s"${a.representation(true).render(40)}.render($wNeg) fails")
+    }
+  }
 
   test("hard union cases") {
     /**
@@ -156,7 +156,7 @@ the spaces""")
      *   (a * n * (b * s * c) | (b * n * c))
      */
     val first = Doc.paragraph("a b c")
-    val second = Doc.fill(Doc.empty, List("a", "b", "c").map(Doc.text))
+    val second = Doc.fill(Doc.spaceOrLine, List("a", "b", "c").map(Doc.text))
     /*
      * I think this fails perhaps because of the way fill constructs
      * Unions. It violates a stronger invariant that Union(a, b)
@@ -217,6 +217,7 @@ the spaces""")
       case Line(d) => okay(d)
       case Concat(a, b) => okay(a) && okay(b)
       case Nest(j, d) => okay(d)
+      case Align(d) => okay(d)
       case u@Union(a, _) =>
         (a.flatten.compare(u.bDoc.flatten) == 0) && okay(a) && okay(u.bDoc)
     }
@@ -232,6 +233,7 @@ the spaces""")
       case Empty => (false, 0)
       case Text(s) => (false, s.length)
       case Nest(j, d) => nextLineLength(d) // nesting only matters AFTER the next line
+      case Align(d) => nextLineLength(d) // aligning only matters AFTER the next line
       case Concat(a, b) =>
         val r1@(done, l) = nextLineLength(a)
         if (!done) {
@@ -244,6 +246,7 @@ the spaces""")
     def okay(d: Doc): Boolean = d match {
       case Empty | Text(_) | Line(_) => true
       case Nest(j, d) => okay(d)
+      case Align(d) => okay(d)
       case Concat(a, b) => okay(a) && okay(b)
       case u@Union(a, _) =>
         nextLineLength(a)._2 >= nextLineLength(u.bDoc)._2
@@ -254,14 +257,13 @@ the spaces""")
 
   test("test json array example") {
     val items = (0 to 20).map(Doc.str(_))
-    val parts = Doc.fill(Doc.comma, items)
-    val ary = "[" +: ((parts :+ "]").nest(2))
-    assert(ary.render(1000) == (0 to 20).mkString("[", ", ", "]"))
+    val parts = Doc.fill(Doc.comma + Doc.line, items)
+    val ary = "[" +: ((parts :+ "]").aligned)
+    assert(ary.renderWideStream.mkString == (0 to 20).mkString("[", ", ", "]"))
     val expect = """[0, 1, 2, 3, 4, 5,
-                   |  6, 7, 8, 9, 10,
-                   |  11, 12, 13, 14,
-                   |  15, 16, 17, 18,
-                   |  19, 20]""".stripMargin
+                   | 6, 7, 8, 9, 10, 11,
+                   | 12, 13, 14, 15, 16,
+                   | 17, 18, 19, 20]""".stripMargin
     assert(ary.render(20) == expect)
   }
 
@@ -273,7 +275,7 @@ the spaces""")
 
   test("test json map example") {
     val kvs = (0 to 20).map { i => text("\"%s\": %s".format(s"key$i", i)) }
-    val parts = Doc.fill(Doc.comma, kvs)
+    val parts = Doc.fill(Doc.comma + Doc.spaceOrLine, kvs)
     val map = parts.bracketBy(Doc.text("{"), Doc.text("}"))
     assert(map.render(1000) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.mkString("{ ", ", ", " }"))
     assert(map.render(20) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.map("  " + _).mkString("{\n", ",\n", "\n}"))
@@ -291,7 +293,7 @@ the spaces""")
     forAll { (d0: Doc, d1: Doc, dsLong: List[Doc]) =>
       // we need at least 2 docs for this law
       val ds = (d0 :: d1 :: dsLong.take(4))
-      val f = Doc.fill(Doc.empty, ds)
+      val f = Doc.fill(Doc.spaceOrLine, ds)
       val g = Doc.intercalate(Doc.space, ds.map(_.flatten))
       assert(g.isSubDocOf(f))
     }
@@ -411,9 +413,9 @@ the spaces""")
     assert(Doc.intercalate(Doc.spaceOrLine, nums.map(Doc.str)).renderWideStream.mkString == nums.mkString(" "))
   }
 
-  test("renderTall == render(0)") {
-    forAll { (d: Doc) =>
-      assert(d.renderTallStream.mkString == d.render(0))
+  test("render(w) == renderStream(w).mkString") {
+    forAll { (d: Doc, w: Int) =>
+      assert(d.render(w) == d.renderStream(w).mkString)
     }
   }
   test("renderWide == render(maxWidth)") {
@@ -433,5 +435,23 @@ the spaces""")
                                 |16,17,18,
                                 |19,20)""".stripMargin)
     assert(res.renderWideStream.mkString == (1 to 20).mkString("(", ",", ")"))
+  }
+  test("align works as expected") {
+    import Doc._
+    // render with alignment
+    val d1 = text("fooooo ") + (text("bar") line text("baz")).aligned
+
+    assert(d1.render(0) == """fooooo bar
+                             |       baz""".stripMargin)
+  }
+
+  test("fill example") {
+    import Doc.{ comma, text, fill }
+    val ds = text("1") :: text("2") :: text("3") :: Nil
+    val doc = fill(comma + Doc.line, ds)
+
+    assert(doc.render(0) == "1,\n2,\n3")
+    assert(doc.render(6) == "1, 2,\n3")
+    assert(doc.render(10) == "1, 2, 3")
   }
 }


### PR DESCRIPTION
This adds two features seen in the haskell implementations of this paper:

1. lineBreak: this is a newline that is flattened to empty. This is actually present in wl-pprint, lending credence to the idea that this is the main custom flattening, but the code *seems* to imply other flattenings would be possible to support.

2. align: which sets the nesting to the current position. This is implemented directly rather than bases on two other combinators in wl-pprint. I did this because those other two combinators, while indeed more general complicate implementation and I couldn't clearly see the value like I could with align. Since we would still have alight later, we retain the option of adding those combinators at needed in the future.

As part of doing this I added a few new laws and found a couple of corner cases that the existence of lineBreak exposes. I also reworked `fill` a bit in a way that I think makes it easier to understand but also useful with `lineBreak` instead of `line`.

Please review this PR @olafurpg @non I think this basically gets us to `0.1.0` and we should publish something soon.