### PR TITLE
Rename some methods

### DIFF
--- a/core/src/test/scala/com/github/johnynek/paiges/Generators.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/Generators.scala
@@ -19,7 +19,7 @@ object Generators {
     (1, Doc.space),
     (1, Doc.line),
     (1, Doc.lineBreak),
-    (1, Doc.spaceOrLine),
+    (1, Doc.lineOrSpace),
     (10, asciiString.map(text(_))),
     (10, generalString.map(text(_))),
     (3, asciiString.map(Doc.split(_))),
@@ -32,13 +32,13 @@ object Generators {
     { (a: Doc, b: Doc) => a + b },
     { (a: Doc, b: Doc) => a space b },
     { (a: Doc, b: Doc) => a / b },
-    { (a: Doc, b: Doc) => a spaceOrLine b })
+    { (a: Doc, b: Doc) => a lineOrSpace b })
 
   val unary: Gen[Doc => Doc] =
     Gen.oneOf(
       Gen.const({ d: Doc => d.grouped }),
       Gen.const({ d: Doc => d.aligned }),
-      Gen.choose(0, 40).map { i => { d: Doc => d.nest(i) } })
+      Gen.choose(0, 40).map { i => { d: Doc => d.nested(i) } })
 
   val folds: Gen[(List[Doc] => Doc)] =
     Gen.oneOf(

--- a/core/src/test/scala/com/github/johnynek/paiges/JsonTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/JsonTest.scala
@@ -35,13 +35,13 @@ object Json {
   case class JArray(toVector: Vector[Json]) extends Json {
     def toDoc = {
       val parts = Doc.intercalate(Doc.comma, toVector.map { j => (Doc.line + j.toDoc).grouped })
-      "[" +: ((parts :+ " ]").nest(2))
+      "[" +: ((parts :+ " ]").nested(2))
     }
   }
   case class JObject(toMap: Map[String, Json]) extends Json {
     def toDoc = {
       val kvs = toMap.map { case (s, j) =>
-        JString(s).toDoc + text(":") + ((Doc.spaceOrLine + j.toDoc).nest(2))
+        JString(s).toDoc + text(":") + ((Doc.lineOrSpace + j.toDoc).nested(2))
       }
       val parts = Doc.fill(Doc.comma, kvs)
       parts.bracketBy(text("{"), text("}"))
@@ -52,7 +52,7 @@ object Json {
 class JsonTest extends FunSuite {
   import Json._
 
-  test("test nested array json example") {
+  test("test nesteded array json example") {
     val inner = JArray((1 to 20).map { i => JNumber(i.toDouble) }.toVector)
     val outer = JArray(Vector(inner, inner, inner))
 

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -17,8 +17,8 @@ class PaigesTest extends FunSuite {
      assert((text("hello") + text("world")).render(100) == "helloworld")
   }
 
-  test("nest test") {
-    assert((text("yo") + (text("yo\nho\nho").nest(2))).render(100) ==
+  test("nested test") {
+    assert((text("yo") + (text("yo\nho\nho").nested(2))).render(100) ==
 """yoyo
   ho
   ho""")
@@ -34,10 +34,10 @@ c""")
     assert(g.render(11) == "hello a b c")
   }
 
-  test("nesting with paragraph") {
+  test("nesteding with paragraph") {
     val words = List("this", "is", "a", "test", "of", "a", "block", "of", "text")
     val d1 = Doc.paragraph(words.mkString(" "))
-    val d2 = d1 + (Doc.line :+ "love, Oscar").nest(2)
+    val d2 = d1 + (Doc.line :+ "love, Oscar").nested(2)
     assert(d2.render(0) == words.mkString("", "\n", "\n  love, Oscar"))
     assert(d2.render(100) == words.mkString("", " ", "\n  love, Oscar"))
   }
@@ -156,7 +156,7 @@ the spaces""")
      *   (a * n * (b * s * c) | (b * n * c))
      */
     val first = Doc.paragraph("a b c")
-    val second = Doc.fill(Doc.spaceOrLine, List("a", "b", "c").map(Doc.text))
+    val second = Doc.fill(Doc.lineOrSpace, List("a", "b", "c").map(Doc.text))
     /*
      * I think this fails perhaps because of the way fill constructs
      * Unions. It violates a stronger invariant that Union(a, b)
@@ -167,11 +167,11 @@ the spaces""")
     assert(first.compare(second) == 0)
 
     /**
-     * spaceOrLine == (s | n)
-     * flatten(spaceOrLine) = s
-     * group(spaceOrLine) = (s | (s|n)) == (s | n)
+     * lineOrSpace == (s | n)
+     * flatten(lineOrSpace) = s
+     * group(lineOrSpace) = (s | (s|n)) == (s | n)
      */
-    assert(Doc.spaceOrLine.grouped.compare(Doc.spaceOrLine) == 0)
+    assert(Doc.lineOrSpace.grouped.compare(Doc.lineOrSpace) == 0)
   }
   test("group law") {
     /**
@@ -232,7 +232,7 @@ the spaces""")
       case Line(_) => (true, 0)
       case Empty => (false, 0)
       case Text(s) => (false, s.length)
-      case Nest(j, d) => nextLineLength(d) // nesting only matters AFTER the next line
+      case Nest(j, d) => nextLineLength(d) // nesteding only matters AFTER the next line
       case Align(d) => nextLineLength(d) // aligning only matters AFTER the next line
       case Concat(a, b) =>
         val r1@(done, l) = nextLineLength(a)
@@ -275,7 +275,7 @@ the spaces""")
 
   test("test json map example") {
     val kvs = (0 to 20).map { i => text("\"%s\": %s".format(s"key$i", i)) }
-    val parts = Doc.fill(Doc.comma + Doc.spaceOrLine, kvs)
+    val parts = Doc.fill(Doc.comma + Doc.lineOrSpace, kvs)
     val map = parts.bracketBy(Doc.text("{"), Doc.text("}"))
     assert(map.render(1000) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.mkString("{ ", ", ", " }"))
     assert(map.render(20) == (0 to 20).map { i => "\"%s\": %s".format(s"key$i", i) }.map("  " + _).mkString("{\n", ",\n", "\n}"))
@@ -293,7 +293,7 @@ the spaces""")
     forAll { (d0: Doc, d1: Doc, dsLong: List[Doc]) =>
       // we need at least 2 docs for this law
       val ds = (d0 :: d1 :: dsLong.take(4))
-      val f = Doc.fill(Doc.spaceOrLine, ds)
+      val f = Doc.fill(Doc.lineOrSpace, ds)
       val g = Doc.intercalate(Doc.space, ds.map(_.flatten))
       assert(g.isSubDocOf(f))
     }
@@ -405,12 +405,12 @@ the spaces""")
   }
 
   test("maxWidth is stack safe") {
-    assert(Doc.intercalate(Doc.spaceOrLine, (1 to 100000).map(Doc.str)).maxWidth >= 0)
+    assert(Doc.intercalate(Doc.lineOrSpace, (1 to 100000).map(Doc.str)).maxWidth >= 0)
   }
 
   test("renderWide is stack safe") {
     val nums = (1 to 100000)
-    assert(Doc.intercalate(Doc.spaceOrLine, nums.map(Doc.str)).renderWideStream.mkString == nums.mkString(" "))
+    assert(Doc.intercalate(Doc.lineOrSpace, nums.map(Doc.str)).renderWideStream.mkString == nums.mkString(" "))
   }
 
   test("render(w) == renderStream(w).mkString") {

--- a/docs/src/main/tut/intro.md
+++ b/docs/src/main/tut/intro.md
@@ -58,9 +58,11 @@ There are also some useful methods defined in the `Doc` companion:
  * `Doc.empty`: an empty document, equivalent to `Doc.text("")`
  * `Doc.space`: a single space, equivalent to `Doc.text(" ")`
  * `Doc.comma`: a single comma, equivalent to `Doc.text(",")`
- * `Doc.line`: a single newline, equivalent to  `Doc.text("\n")`
+ * `Doc.line`: a single newline, equivalent to  `Doc.text("\n")`. When flattened, this becomes space.
+ * `Doc.lineBreak`: a single newline that flattens to empty.
  * `Doc.spaces(n)`: *n* spaces, equivalent to `Doc.text(" " * n)`
- * `Doc.spaceOrLine`: a space or newline, depending upon rendering width
+ * `Doc.lineOrSpace`: a space or newline, depending upon rendering width
+ * `Doc.lineOrEmpty`: empty or newline, depending upon rendering width
 
 ## Combining documents
 


### PR DESCRIPTION
Addresses #27 and @olafurpg's suggestion: https://github.com/johnynek/paiges/pull/29#discussion_r110709957

I didn't exactly rename `lineBreak` to `lineOrEmpty` since it is not actually a union. I added `lineOrEmpty = lineBreak.grouped`. The bare `lineBreak` is a bit confusing without `.grouped` in the picture, since in that case `line == lineOrEmpty`. This brings up a weird issue.

`line.compare(lineBreak) == 0` since indeed they do render identically. But actually `line.grouped.compare(lineBreak.grouped) == 1`.

So, you have a case where `a == b` but `f(a) != f(b)`. Which seems like a bug to me.