### PR TITLE
Fix Ordering after we have align and lineBreak

### DIFF
--- a/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
@@ -24,7 +24,7 @@ private object Chunk {
    *
    * The indentation must be non-negative.
    */
-  case class Break(indent: Int, flattenToSpace: Boolean) extends Chunk {
+  case class Break(indent: Int, flattenToSpace: Boolean, absolute: Boolean) extends Chunk {
     def str: String = lineToStr(indent)
   }
 

--- a/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
+++ b/core/src/main/scala/com/github/johnynek/paiges/Chunk.scala
@@ -24,7 +24,7 @@ private object Chunk {
    *
    * The indentation must be non-negative.
    */
-  case class Break(indent: Int) extends Chunk {
+  case class Break(indent: Int, flattenToSpace: Boolean) extends Chunk {
     def str: String = lineToStr(indent)
   }
 

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -454,4 +454,23 @@ the spaces""")
     assert(doc.render(6) == "1, 2,\n3")
     assert(doc.render(10) == "1, 2, 3")
   }
+
+  test("a == b implies f(a) == f(b)") {
+    import Doc.docOrdering
+
+    def law(a: Doc, b: Doc, f: Doc => Doc) =
+      if (docOrdering.equiv(a, b)) {
+        assert(docOrdering.equiv(f(a), f(b)), s"${a.representation(true).render(40)}\n\n${b.representation(true).render(40)}")
+      }
+      else ()
+
+    // Here are some hard cases
+    val examples = List((Doc.line, Doc.lineBreak, { (d: Doc) => d.grouped }))
+    examples.foreach { case (a, b, f) => law(a, b, f) }
+
+    implicit val generatorDrivenConfig =
+      PropertyCheckConfiguration(minSuccessful = 5000)
+
+    forAll(genDoc, genDoc, unary) { (a, b, f) => law(a, b, f) }
+  }
 }

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -213,8 +213,7 @@ the spaces""")
   test("the left and right side of a union are the same after flattening") {
     import Doc._
     def okay(d: Doc): Boolean = d match {
-      case Empty | Text(_) => true
-      case Line(d) => okay(d)
+      case Empty | Text(_) | Line(_) => true
       case Concat(a, b) => okay(a) && okay(b)
       case Nest(j, d) => okay(d)
       case Align(d) => okay(d)
@@ -465,7 +464,11 @@ the spaces""")
       else ()
 
     // Here are some hard cases
-    val examples = List((Doc.line, Doc.lineBreak, { (d: Doc) => d.grouped }))
+    val examples = List(
+      (Doc.line, Doc.lineBreak, { (d: Doc) => d.grouped }),
+      (Doc.lineOrSpace, Doc.lineOrSpace.aligned, { (d: Doc) => d.nested(1) })
+    )
+
     examples.foreach { case (a, b, f) => law(a, b, f) }
 
     implicit val generatorDrivenConfig =

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -11,7 +11,7 @@ class PaigesTest extends FunSuite {
   import Doc.text
 
   implicit val generatorDrivenConfig =
-    PropertyCheckConfiguration(minSuccessful = 5000)
+    PropertyCheckConfiguration(minSuccessful = 500)
 
   test("basic test") {
      assert((text("hello") + text("world")).render(100) == "helloworld")
@@ -129,7 +129,7 @@ the spaces""")
       assert(goodW.forall { w => d.render(w) == maxR })
     }
   }
-  test("if we always render the same, we compare the same") {
+  test("if we compare the same we render the same") {
     forAll { (a: Doc, b: Doc) =>
       if(a.compare(b) == 0) {
         val maxR = a.maxWidth max b.maxWidth
@@ -367,9 +367,7 @@ the spaces""")
       if (a.isSubDocOf(b)) {
         assert(SortedSet(da: _*).subsetOf(SortedSet(db: _*)))
       }
-      else {
-        ()
-      }
+      else succeed
     }
   }
   test("Doc.repeat matches naive implementation") {

--- a/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
+++ b/core/src/test/scala/com/github/johnynek/paiges/PaigesTest.scala
@@ -11,7 +11,7 @@ class PaigesTest extends FunSuite {
   import Doc.text
 
   implicit val generatorDrivenConfig =
-    PropertyCheckConfiguration(minSuccessful = 500)
+    PropertyCheckConfiguration(minSuccessful = 5000)
 
   test("basic test") {
      assert((text("hello") + text("world")).render(100) == "helloworld")
@@ -131,11 +131,12 @@ the spaces""")
   }
   test("if we always render the same, we compare the same") {
     forAll { (a: Doc, b: Doc) =>
-      val maxR = a.maxWidth max b.maxWidth
-      val allSame = (0 to maxR).forall { w =>
-        a.render(w) == b.render(w)
+      if(a.compare(b) == 0) {
+        val maxR = a.maxWidth max b.maxWidth
+        val allSame = (0 to maxR).forall { w =>
+          a.render(w) == b.render(w)
+        }
       }
-      if (allSame) assert(a.compare(b) == 0)
       else succeed
     }
   }
@@ -348,7 +349,6 @@ the spaces""")
           case Some(bMinusA) =>
             // disjoint or overlapping, so atree and bMinusA are disjoint
             assert(!DocTree.isSubDoc(atree, bMinusA))
-            assert(((DocTree.deunioned(atree).toSet) & (DocTree.deunioned(bMinusA).toSet)).isEmpty)
         }
       }
     }
@@ -360,11 +360,16 @@ the spaces""")
     }
   }
 
-  test("if deunioned is a subset, then isSubDocOf") {
+  test("if isSubDocOf then deunioned is a subset") {
     forAll { (a: Doc, b: Doc) =>
       val da = a.deunioned
       val db = b.deunioned
-      assert(a.isSubDocOf(b) == SortedSet(da: _*).subsetOf(SortedSet(db: _*)))
+      if (a.isSubDocOf(b)) {
+        assert(SortedSet(da: _*).subsetOf(SortedSet(db: _*)))
+      }
+      else {
+        ()
+      }
     }
   }
   test("Doc.repeat matches naive implementation") {


### PR DESCRIPTION
Certainly after adding lineBreak in #29 (and possibly even before, I haven't checked), some expectations around equality are broken.

To fix these, we have to remember two bits of information around `Line`: we keep if the line should be flattened into space or line, and if the spaces after a line are absolute (from aligned) or relative (from nested).

This weakens the `deunioned` which was already private and only used for law checking. The problem is that two different `Doc` items are deunioned into the same set of Docs.